### PR TITLE
Fix boundaries script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,8 +3,14 @@ notes.txt
 localconfig*.js
 project.xml
 *~
-tmp/*
+tmp/
 *.mbtiles
 *.xml
+bin/
+include/
+lib/
 node_modules/
 __pycache__/
+.Python
+.pydevproject
+/pip-selfcheck.json

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ update:
 	env PGHOST=/var/run/postgresql/ imposm3 run -config imposm.conf
 boundary:
 	python scripts/make_boundaries.py process
-	ogr2ogr --config PG_USE_COPY YES -lco GEOMETRY_NAME=geometry -lco DROP_TABLE=IF_EXISTS -f PGDump tmp/boundary.sql tmp/boundary.json -select name,'name:en','name:fr','name:ar' -nln itl_boundary
+	ogr2ogr --config PG_USE_COPY YES -lco GEOMETRY_NAME=geometry -lco DROP_TABLE=IF_EXISTS -f PGDump tmp/boundary.sql data/boundary.json -select name,'name:en','name:fr','name:ar','name:es','name:de','name:ru' -nln itl_boundary
 	# Remove transaction management, as it does not cover the DROP TABLE; we'll cover the transaction manually with "psql --single-transaction"
 	sed --in-place '/BEGIN;/d' tmp/boundary.sql
 	sed --in-place '/END;/d' tmp/boundary.sql

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ boundary:
 	python scripts/make_boundaries.py process
 	ogr2ogr --config PG_USE_COPY YES -lco GEOMETRY_NAME=geometry -lco DROP_TABLE=IF_EXISTS -f PGDump tmp/boundary.sql data/boundary.json -select name,'name:en','name:fr','name:ar','name:es','name:de','name:ru' -nln itl_boundary
 	# Remove transaction management, as it does not cover the DROP TABLE; we'll cover the transaction manually with "psql --single-transaction"
-	sed --in-place '/BEGIN;/d' tmp/boundary.sql
-	sed --in-place '/END;/d' tmp/boundary.sql
-	sed --in-place '/COMMIT;/d' tmp/boundary.sql
+	sed -i.bak '/BEGIN;/d' tmp/boundary.sql
+	sed -i.bak '/END;/d' tmp/boundary.sql
+	sed -i.bak '/COMMIT;/d' tmp/boundary.sql
+	rm tmp/boundary.sql.bak

--- a/scripts/make_boundaries.py
+++ b/scripts/make_boundaries.py
@@ -29,7 +29,7 @@ COUNTRIES = [
     "BW",  # Botswana
     "BR",  # Brazil
     "IO",  # British Indian Ocean Territory
-    #"British Sovereign Base Areas",  # British Sovereign Base Areas
+    "British Sovereign Base Areas",  # British Sovereign Base Areas
     "VG",  # British Virgin Islands
     "BN",  # Brunei
     "BF",  # Burkina Faso
@@ -234,7 +234,7 @@ COUNTRIES = [
 
 
 async def get_relation(conn, **tags):
-    tags = "".join(f'["{k.replace("iso","ISO3166-1:alpha2")}"="{v}"]' for k, v in tags.items())
+    tags = "".join(f'["{k.replace("iso","ISO3166-1:alpha2") if (k == "iso" and len(v) == 2) else k.replace("iso","name")}"="{v}"]' for k, v in tags.items())
     dir = Path('tmp/boundary');
     if not dir.is_dir():
         dir.mkdir(parents=True);
@@ -344,37 +344,37 @@ async def process(itl_path: Path=Path('data/boundary.json'),
     add_disputed(halaib_triangle, props)
     for idx, name in enumerate(COUNTRIES):
         polygon, properties = await load_country(conn, name)
-        if properties['ISO3166-1:alpha2'] == 'EH':
+        if 'ISO3166-1:alpha2' in properties and properties['ISO3166-1:alpha2'] == 'EH':
             continue
-        print(f'''"{properties['name']}",  # {properties['name:en']} - {properties['ISO3166-1:alpha2']}''')
-        if properties['ISO3166-1:alpha2'] == 'IL':
+        print(f'''"{properties['name']}",  # {properties['name:en']}''')
+        if  'ISO3166-1:alpha2' in properties and properties['ISO3166-1:alpha2'] == 'IL':
             polygon = await remove_area(conn, polygon, golan)
             west_bank, _ = await get_relation(conn, place="region",
                                               name="الضفة الغربية")
             polygon = await remove_area(conn, polygon, west_bank)
-        if properties['ISO3166-1:alpha2'] == 'SY':
+        if  'ISO3166-1:alpha2' in properties and properties['ISO3166-1:alpha2'] == 'SY':
             polygon = await add_area(conn, polygon, golan)
-        if properties['ISO3166-1:alpha2'] == 'SD':
+        if  'ISO3166-1:alpha2' in properties and properties['ISO3166-1:alpha2'] == 'SD':
             sudan, _ = await load_country(conn, 'SD')  # Sudan
             polygon = await remove_area(conn, polygon, sudan)
         if properties['name:en'] == 'Sudan':
             polygon = await remove_area(conn, polygon, bir_tawil)
-        if properties['ISO3166-1:alpha2'] == 'EG':
+        if 'ISO3166-1:alpha2' in properties and properties['ISO3166-1:alpha2'] == 'EG':
             polygon = await add_area(conn, polygon, bir_tawil)
-        if properties['ISO3166-1:alpha2'] == 'NP':
+        if 'ISO3166-1:alpha2' in properties and properties['ISO3166-1:alpha2'] == 'NP':
             claim, props = await get_relation(conn, type="boundary",
                                               name="Extent of Nepal Claim")
             add_disputed(claim, props)
             polygon = await add_area(conn, polygon, claim)
-        if properties['ISO3166-1:alpha2'] == 'IN':
+        if 'ISO3166-1:alpha2' in properties and properties['ISO3166-1:alpha2'] == 'IN':
             claim, _ = await get_relation(conn, type="boundary",
                                           name="Extent of Nepal Claim")
             polygon = await remove_area(conn, polygon, claim)
-        if properties['ISO3166-1:alpha2'] == 'CN':
+        if 'ISO3166-1:alpha2' in properties and properties['ISO3166-1:alpha2'] == 'CN':
             polygon = await remove_area(conn, polygon, doklam)
-        if properties['ISO3166-1:alpha2'] == 'BH':
+        if 'ISO3166-1:alpha2' in properties and properties['ISO3166-1:alpha2'] == 'BH':
             polygon = await add_area(conn, polygon, doklam)
-        if properties['ISO3166-1:alpha2'] == 'MA':
+        if 'ISO3166-1:alpha2' in properties and properties['ISO3166-1:alpha2'] == 'MA':
             # Western Sahara
             esh, props = await get_relation(conn, boundary="disputed",
                                             name="الصحراء الغربية")

--- a/scripts/make_boundaries.py
+++ b/scripts/make_boundaries.py
@@ -195,7 +195,7 @@ COUNTRIES = [
     "PS",  # Palestine
     "JO",  # Jordan
     "AE",  # United Arab Emirates
-    "ES",   # Sahrawi Arab Democratic Republic
+    "EH",  # Western Sahara
     "SA",  # Saudi Arabia
     "SD",  # Sudan
     "IQ",  # Iraq

--- a/scripts/make_boundaries.py
+++ b/scripts/make_boundaries.py
@@ -354,7 +354,7 @@ async def process(itl_path: Path=Path('data/boundary.json'),
             polygon = await remove_area(conn, polygon, west_bank)
         if  'ISO3166-1:alpha2' in properties and properties['ISO3166-1:alpha2'] == 'SY':
             polygon = await add_area(conn, polygon, golan)
-        if  'ISO3166-1:alpha2' in properties and properties['ISO3166-1:alpha2'] == 'SD':
+        if  'ISO3166-1:alpha2' in properties and properties['ISO3166-1:alpha2'] == 'SS':
             sudan, _ = await load_country(conn, 'SD')  # Sudan
             polygon = await remove_area(conn, polygon, sudan)
         if properties['name:en'] == 'Sudan':

--- a/scripts/make_boundaries.py
+++ b/scripts/make_boundaries.py
@@ -11,236 +11,235 @@ from postgis.asyncpg import register
 OVERPASS = 'http://overpass-api.de/api/interpreter'
 
 COUNTRIES = [
-    "Andorra",  # Andorra
-    "Angola",  # Angola
-    "Anguilla",  # Anguilla
-    "Antigua and Barbuda",  # Antigua and Barbuda
-    "Argentina",  # Argentina
-    "Australia",  # Australia
-    "Ayiti",  # Haiti
-    "Azərbaycan",  # Azerbaijan
-    "Barbados",  # Barbados
-    "Belau",  # Palau
-    "België / Belgique / Belgien",  # Belgium
-    "Belize",  # Belize
-    "Bermuda",  # Bermuda
-    "Bolivia",  # Bolivia
-    "Bosna i Hercegovina / Босна и Херцеговина",  # Bosnia and Herzegovina
-    "Botswana",  # Botswana
-    "Brasil",  # Brazil
-    "British Indian Ocean Territory",  # British Indian Ocean Territory
-    "British Sovereign Base Areas",  # British Sovereign Base Areas
-    "British Virgin Islands",  # British Virgin Islands
-    "Brunei Darussalam",  # Brunei
-    "Burkina Faso",  # Burkina Faso
-    "Burundi",  # Burundi
-    "Bénin",  # Benin
-    "Cabo Verde",  # Cape Verde
-    "Cameroun",  # Cameroon
-    "Canada",  # Canada
-    "Cayman Islands",  # Cayman Islands
-    "Chile",  # Chile
-    "Città del Vaticano",  # Vatican City
-    "Colombia",  # Colombia
-    "Comores Komori جزر القمر",  # Comoros
-    "Congo",  # Congo-Brazzaville
-    "Kūki 'Āirani",  # Cook Islands
-    "Costa Rica",  # Costa Rica
-    "Crna Gora / Црна Гора",  # Montenegro
-    "Cuba",  # Cuba
-    "Côte d’Ivoire",  # Côte d'Ivoire
-    "Danmark",  # Denmark
-    "Deutschland",  # Germany
-    "Djibouti جيبوتي",  # Djibouti
-    "Dominica",  # Dominica
-    "Ecuador",  # Ecuador
-    "Eesti",  # Estonia
-    "El Salvador",  # El Salvador
-    "España",  # Spain
-    "eSwatini Swaziland",  # Swaziland
-    "Falkland Islands (Malvinas)",  # Falkland Islands
-    "France",  # France
-    "Føroyar",  # Faroe Islands
-    "Gabon",  # Gabon
-    "Gambia",  # Gambia
-    "Ghana",  # Ghana
-    "Gibraltar",  # Gibraltar
-    "Grenada",  # Grenada
-    "Guatemala",  # Guatemala
-    "Guernsey",  # Guernsey
-    "Guinea Ecuatorial",  # Equatorial Guinea
-    "Guiné-Bissau",  # Guinea-Bissau
-    "Guinée",  # Guinea
-    "Guyana",  # Guyana
-    "Honduras",  # Honduras
-    "Hrvatska",  # Croatia
-    "India",  # India
-    "Indonesia",  # Indonesia
-    "Ireland",  # Ireland
-    "Isle of Man",  # Isle of Man
-    "Italia",  # Italy
-    "Jamaica",  # Jamaica
-    "Jersey",  # Jersey
-    "Kalaallit Nunaat",  # Greenland
-    "Kenya",  # Kenya
-    "Kiribati",  # Kiribati
-    "Ködörösêse tî Bêafrîka - République Centrafricaine",  # Central African
-                                                           # Republic
-    "Latvija",  # Latvia
-    "Lesotho",  # Lesotho
-    "Liberia",  # Liberia
-    "Liechtenstein",  # Liechtenstein
-    "Lietuva",  # Lithuania
-    "Lëtzebuerg",  # Luxembourg
-    "Madagasikara",  # Madagascar
-    "Magyarország",  # Hungary
-    "Malawi",  # Malawi
-    "Malaysia",  # Malaysia
-    "Mali",  # Mali
-    "Malta",  # Malta
-    "Maroc ⵍⵎⵖⵔⵉⴱ المغرب",  # Morocco
-    "Mauritius",  # Mauritius
-    "Micronesia",  # Federated States of Micronesia
-    "Moldova",  # Moldova
-    "Monaco",  # Monaco
-    "Monaco",  # Monaco
-    "Montserrat",  # Montserrat
-    "Moçambique",  # Mozambique
-    "México",  # Mexico
-    "M̧ajeļ",  # Marshall Islands
-    "Namibia",  # Namibia
-    "Naoero",  # Nauru
-    "Nederland",  # The Netherlands
-    "New Zealand/Aotearoa",  # New Zealand
-    "Nicaragua",  # Nicaragua
-    "Niger",  # Niger
-    "Nigeria",  # Nigeria
-    "Niuē",  # Niue
-    "Norge",  # Norway
-    "Oʻzbekiston",  # Uzbekistan
-    "Panamá",  # Panama
-    "Papua Niugini",  # Papua New Guinea
-    "Paraguay",  # Paraguay
-    "Perú",  # Peru
-    "Philippines",  # Philippines
-    "Pitcairn Islands",  # Pitcairn Islands
-    "Polska",  # Poland
-    "Portugal",  # Portugal
-    "Kosova",  # Kosovo
-    "República Dominicana",  # Dominican Republic
-    "România",  # Romania
-    "Rwanda",  # Rwanda
-    "République démocratique du Congo",  # Democratic Republic of the Congo
-    "Saint Helena, Ascension and Tristan da Cunha",  # Saint Helena, Ascension
-                                                     # and Tristan da Cunha
-    "Saint Kitts and Nevis",  # Saint Kitts and Nevis
-    "Saint Lucia",  # Saint Lucia
-    "Saint Vincent and the Grenadines",  # Saint Vincent and the Grenadines
-    "San Marino",  # San Marino
-    "Schweiz/Suisse/Svizzera/Svizra",  # Switzerland
-    "Sesel",  # Seychelles
-    "Shqipëria",  # Albania
-    "Sierra Leone",  # Sierra Leone
-    "Singapore",  # Singapore
-    "Slovenija",  # Slovenia
-    "Slovensko",  # Slovakia
-    "Solomon Islands",  # Solomon Islands
-    "Soomaaliya الصومال",  # Somalia
-    "South Africa",  # South Africa
-    "South Georgia and South Sandwich Islands",  # South Georgia and the South
-                                                 # Sandwich Islands
-    "South Sudan",  # South Sudan
-    "Suomi",  # Finland
-    "Suriname",  # Suriname
-    "Sverige",  # Sweden
-    "São Tomé e Príncipe",  # São Tomé and Príncipe
-    "Sénégal",  # Senegal
-    "Sāmoa",  # Samoa
-    "Tanzania",  # Tanzania
-    "Tchad تشاد",  # Chad
-    "The Bahamas",  # The Bahamas
-    "Timór Lorosa'e",  # East Timor
-    "Togo",  # Togo
-    "Tokelau",  # Tokelau
-    "Tonga",  # Tonga
-    "Trinidad and Tobago",  # Trinidad and Tobago
-    "Turks and Caicos Islands",  # Turks and Caicos Islands
-    "Tuvalu",  # Tuvalu
-    "Türkiye",  # Turkey
-    "Türkmenistan",  # Turkmenistan
-    "Uganda",  # Uganda
-    "United Kingdom",  # United Kingdom
-    "United States of America",  # United States of America
-    "Uruguay",  # Uruguay
-    "Vanuatu",  # Vanuatu
-    "Venezuela",  # Venezuela
-    "Viti",  # Fiji
-    "Việt Nam",  # Vietnam
-    "Zambia",  # Zambia
-    "Zimbabwe",  # Zimbabwe
-    "Ísland",  # Iceland
-    "Österreich",  # Austria
-    "Česko",  # Czechia
-    "Ελλάδα",  # Greece
-    "Κύπρος - Kıbrıs",  # Cyprus
-    "Беларусь",  # Belarus
-    "България",  # Bulgaria
-    "Кыргызстан",  # Kyrgyzstan
-    "Македонија",  # Macedonia
-    "Монгол улс",  # Mongolia
-    "Россия",  # Russia
-    "Србија",  # Serbia
-    "Тоҷикистон",  # Tajikistan
-    "Україна",  # Ukraine
-    "Қазақстан",  # Kazakhstan
-    "Հայաստան",  # Armenia
-    "מדינת ישראל",  # Israel
-    "افغانستان",  # Afghanistan
-    "الأراضي الفلسطينية",  # Palestine
-    "الأردن",  # Jordan
-    "الإمارات العربيّة المتّحدة",  # United Arab Emirates
-    "الجمهورية العربية الصحراوية الديمقراطية‎‎",   # Sahrawi Arab Democratic
-                                                 # Republic
-    "السعودية",  # Saudi Arabia
-    "السودان",  # Sudan
-    "العراق",  # Iraq
-    "اليمن",  # Yemen
-    "تونس",  # Tunisia
-    "سوريا",  # Syria
-    "عمان",  # Oman
-    "لبنان",  # Lebanon
-    "مصر",  # Egypt
-    "موريتانيا",  # Mauritania
-    "ދިވެހިރާއްޖެ",  # Maldives
-    "नेपाल",  # Nepal
-    "বাংলাদেশ",  # Bangladesh
-    "ශ්‍රී ලංකාව இலங்கை",  # Sri Lanka
-    "ประเทศไทย",  # Thailand
-    "ປະເທດລາວ",  # Laos
-    "འབྲུག་ཡུལ་",  # Bhutan
-    "မြန်မာ",  # Myanmar
-    "საქართველო",  # Georgia
-    "ኢትዮጵያ",  # Ethiopia
-    "ኤርትራ إرتريا",  # Eritrea
-    "ព្រះរាជាណាចក្រ​កម្ពុជា",  # Cambodia
-    "‏البحرين‎",  # Bahrain
-    "‏الكويت‎",  # Kuwait
-    "‏ایران‎",  # Iran
-    "‏قطر‎",  # Qatar
-    "‏پاکستان‎",  # Pakistan
-    "ⵍⵉⴱⵢⴰ ليبيا",  # Libya
-    "ⵍⵣⵣⴰⵢⴻⵔ الجزائر",  # Algeria
-    "中国",  # China
-    "日本",  # Japan
-    "臺灣",  # Taiwan
-    "대한민국",  # South Korea
-    "조선민주주의인민공화국",  # North Korea
+    "AD",  # Andorra
+    "AO",  # Angola
+    "AI",  # Anguilla
+    "AG",  # Antigua and Barbuda
+    "AR",  # Argentina
+    "AU",  # Australia
+    "HT",  # Haiti
+    "AZ",  # Azerbaijan
+    "BB",  # Barbados
+    "PW",  # Palau
+    "BE",  # Belgium
+    "BZ",  # Belize
+    "BM",  # Bermuda
+    "BO",  # Bolivia
+    "BA",  # Bosnia and Herzegovina
+    "BW",  # Botswana
+    "BR",  # Brazil
+    "IO",  # British Indian Ocean Territory
+    #"British Sovereign Base Areas",  # British Sovereign Base Areas
+    "VG",  # British Virgin Islands
+    "BN",  # Brunei
+    "BF",  # Burkina Faso
+    "BI",  # Burundi
+    "BJ",  # Benin
+    "CV",  # Cape Verde
+    "CM",  # Cameroon
+    "CA",  # Canada
+    "KY",  # Cayman Islands
+    "CL",  # Chile
+    "CA",  # Vatican City
+    "CO",  # Colombia
+    "KM",  # Comoros
+    "CG",  # Congo-Brazzaville
+    "CK",  # Cook Islands
+    "CR",  # Costa Rica
+    "ME",  # Montenegro
+    "CU",  # Cuba
+    "CI",  # Côte d'Ivoire
+    "DK",  # Denmark
+    #"DE",  # Germany
+    "DJ",  # Djibouti
+    "DM",  # Dominica
+    "EC",  # Ecuador
+    "EE",  # Estonia
+    "SV",  # El Salvador
+    "ES",  # Spain
+    "SZ",  # Swaziland
+    "FK",  # Falkland Islands
+    "FR",  # France
+    "FO",  # Faroe Islands
+    "GA",  # Gabon
+    "GM",  # Gambia
+    "GH",  # Ghana
+    "GI",  # Gibraltar
+    "GD",  # Grenada
+    "GT",  # Guatemala
+    "GG",  # Guernsey
+    "GQ",  # Equatorial Guinea
+    "GW",  # Guinea-Bissau
+    "GN",  # Guinea
+    "GY",  # Guyana
+    "HN",  # Honduras
+    "HR",  # Croatia
+    "IN",  # India
+    "ID",  # Indonesia
+    "IE",  # Ireland
+    "IM",  # Isle of Man
+    "IT",  # Italy
+    "JM",  # Jamaica
+    "JE",  # Jersey
+    "GL",  # Greenland
+    "KE",  # Kenya
+    "KI",  # Kiribati
+    "CF",  # Central African Republic
+    "LV",  # Latvia
+    "LS",  # Lesotho
+    "LR",  # Liberia
+    "LY",  # Liechtenstein
+    "LT",  # Lithuania
+    "LU",  # Luxembourg
+    "MG",  # Madagascar
+    "HU",  # Hungary
+    "MW",  # Malawi
+    "MY",  # Malaysia
+    "ML",  # Mali
+    "MT",  # Malta
+    "MA",  # Morocco
+    "MU",  # Mauritius
+    "FM",  # Federated States of Micronesia
+    "MD",  # Moldova
+    "MC",  # Monaco
+    "MS",  # Montserrat
+    "MZ",  # Mozambique
+    "MX",  # Mexico
+    "MH",  # Marshall Islands
+    "NA",  # Namibia
+    "NR",  # Nauru
+    "NL",  # The Netherlands
+    "NZ",  # New Zealand
+    "NI",  # Nicaragua
+    "NE",  # Niger
+    "NG",  # Nigeria
+    "NU",  # Niue
+    "NO",  # Norway
+    "UZ",  # Uzbekistan
+    "PA",  # Panama
+    "PG",  # Papua New Guinea
+    "PY",  # Paraguay
+    "PE",  # Peru
+    "PH",  # Philippines
+    "PN",  # Pitcairn Islands
+    "PL",  # Poland
+    "PT",  # Portugal
+    "XK",  # Kosovo
+    "DO",  # Dominican Republic
+    "RO",  # Romania
+    "RW",  # Rwanda
+    "CD",  # Democratic Republic of the Congo
+    "SH",  # Saint Helena, Ascension and Tristan da Cunha
+    "KN",  # Saint Kitts and Nevis
+    "LC",  # Saint Lucia
+    "VC",  # Saint Vincent and the Grenadines
+    "SM",  # San Marino
+    "CH",  # Switzerland
+    "SC",  # Seychelles
+    "AL",  # Albania
+    "SL",  # Sierra Leone
+    "SG",  # Singapore
+    "SI",  # Slovenia
+    "SK",  # Slovakia
+    "SB",  # Solomon Islands
+    "SO",  # Somalia
+    "ZA",  # South Africa
+    "GS",  # South Georgia and the South Sandwich Islands
+    "SS",  # South Sudan
+    "FI",  # Finland
+    "SR",  # Suriname
+    "SE",  # Sweden
+    "ST",  # São Tomé and Príncipe
+    "SN",  # Senegal
+    "WS",  # Samoa
+    "TZ",  # Tanzania
+    "TD",  # Chad
+    "BS",  # The Bahamas
+    "TL",  # East Timor
+    "TG",  # Togo
+    "TK",  # Tokelau
+    "TO",  # Tonga
+    "TT",  # Trinidad and Tobago
+    "TC",  # Turks and Caicos Islands
+    "TV",  # Tuvalu
+    "TR",  # Turkey
+    "TM",  # Turkmenistan
+    "UG",  # Uganda
+    "GB",  # United Kingdom
+    "US",  # United States of America
+    "UY",  # Uruguay
+    "VU",  # Vanuatu
+    "VE",  # Venezuela
+    "FJ",  # Fiji
+    "VN",  # Vietnam
+    "ZM",  # Zambia
+    "ZW",  # Zimbabwe
+    "IS",  # Iceland
+    "AT",  # Austria
+    "CZ",  # Czechia
+    "GR",  # Greece
+    "CY",  # Cyprus
+    #"BY",  # Belarus
+    "BG",  # Bulgaria
+    "KG",  # Kyrgyzstan
+    "MK",  # Macedonia
+    "MN",  # Mongolia
+    #"RU",  # Russia
+    "RS",  # Serbia
+    "TJ",  # Tajikistan
+    #"UA",  # Ukraine
+    "KZ",  # Kazakhstan
+    "AM",  # Armenia
+    "IL",  # Israel
+    "AF",  # Afghanistan
+    "PS",  # Palestine
+    "JO",  # Jordan
+    "AE",  # United Arab Emirates
+    "ES",   # Sahrawi Arab Democratic Republic
+    "SA",  # Saudi Arabia
+    "SD",  # Sudan
+    "IQ",  # Iraq
+    "YE",  # Yemen
+    "TN",  # Tunisia
+    "SY",  # Syria
+    "OM",  # Oman
+    "LB",  # Lebanon
+    "EG",  # Egypt
+    "MR",  # Mauritania
+    "MV",  # Maldives
+    "NP",  # Nepal
+    "BD",  # Bangladesh
+    "LK",  # Sri Lanka
+    "TH",  # Thailand
+    "LA",  # Laos
+    "BT",  # Bhutan
+    "MM",  # Myanmar
+    "GE",  # Georgia
+    "ET",  # Ethiopia
+    "ER",  # Eritrea
+    "KH",  # Cambodia
+    "BH",  # Bahrain
+    "KW",  # Kuwait
+    "IR",  # Iran
+    "QA",  # Qatar
+    "PK",  # Pakistan
+    "LY",  # Libya
+    "DZ",  # Algeria
+    "CN",  # China
+    "JP",  # Japan
+    "TW",  # Taiwan
+    "KR",  # South Korea
+    "KP",  # North Korea
 ]
 
 
 async def get_relation(conn, **tags):
-    tags = "".join(f'["{k}"="{v}"]' for k, v in tags.items())
+    tags = "".join(f'["{k.replace("iso","ISO3166-1:alpha2")}"="{v}"]' for k, v in tags.items())
+    dir = Path('tmp/boundary');
+    if not dir.is_dir():
+        dir.mkdir(parents=True);
     path = Path('tmp') / 'boundary' / tags.replace('/', '_')
+    print(tags)
     if not path.exists():
         params = {'data': f'[out:json];relation{tags};(._;>;);out body;'}
         resp = requests.get(OVERPASS, params=params)
@@ -312,13 +311,13 @@ async def add_area(conn, shape, other):
         'SELECT ST_Union($1::geometry, $2::geometry)', shape, other)
 
 
-async def load_country(conn, name):
+async def load_country(conn, iso):
     return await get_relation(conn, boundary='administrative', admin_level=2,
-                              name=name)
+                              iso=iso)
 
 
 @cli
-async def process(itl_path: Path=Path('tmp/boundary.json'),
+async def process(itl_path: Path=Path('data/boundary.json'),
                   disputed_path: Path=Path('data/disputed.json')):
     conn = await asyncpg.connect(database='pianoforte')
     await register(conn)
@@ -345,37 +344,37 @@ async def process(itl_path: Path=Path('tmp/boundary.json'),
     add_disputed(halaib_triangle, props)
     for idx, name in enumerate(COUNTRIES):
         polygon, properties = await load_country(conn, name)
-        if properties['name:en'] == 'Sahrawi Arab Democratic Republic':
+        if properties['ISO3166-1:alpha2'] == 'EH':
             continue
-        print(f'''"{properties['name']}",  # {properties['name:en']}''')
-        if properties['name:en'] == 'Israel':
+        print(f'''"{properties['name']}",  # {properties['name:en']} - {properties['ISO3166-1:alpha2']}''')
+        if properties['ISO3166-1:alpha2'] == 'IL':
             polygon = await remove_area(conn, polygon, golan)
             west_bank, _ = await get_relation(conn, place="region",
                                               name="الضفة الغربية")
             polygon = await remove_area(conn, polygon, west_bank)
-        if properties['name:en'] == 'Syria':
+        if properties['ISO3166-1:alpha2'] == 'SY':
             polygon = await add_area(conn, polygon, golan)
-        if properties['name:en'] == 'South Sudan':
-            sudan, _ = await load_country(conn, 'السودان')  # Sudan
+        if properties['ISO3166-1:alpha2'] == 'SD':
+            sudan, _ = await load_country(conn, 'SD')  # Sudan
             polygon = await remove_area(conn, polygon, sudan)
         if properties['name:en'] == 'Sudan':
             polygon = await remove_area(conn, polygon, bir_tawil)
-        if properties['name:en'] == 'Egypt':
+        if properties['ISO3166-1:alpha2'] == 'EG':
             polygon = await add_area(conn, polygon, bir_tawil)
-        if properties['name:en'] == 'Nepal':
+        if properties['ISO3166-1:alpha2'] == 'NP':
             claim, props = await get_relation(conn, type="boundary",
                                               name="Extent of Nepal Claim")
             add_disputed(claim, props)
             polygon = await add_area(conn, polygon, claim)
-        if properties['name:en'] == 'India':
+        if properties['ISO3166-1:alpha2'] == 'IN':
             claim, _ = await get_relation(conn, type="boundary",
                                           name="Extent of Nepal Claim")
             polygon = await remove_area(conn, polygon, claim)
-        if properties['name:en'] == 'China':
+        if properties['ISO3166-1:alpha2'] == 'CN':
             polygon = await remove_area(conn, polygon, doklam)
-        if properties['name:en'] == 'Bhutan':
+        if properties['ISO3166-1:alpha2'] == 'BH':
             polygon = await add_area(conn, polygon, doklam)
-        if properties['name:en'] == 'Morocco':
+        if properties['ISO3166-1:alpha2'] == 'MA':
             # Western Sahara
             esh, props = await get_relation(conn, boundary="disputed",
                                             name="الصحراء الغربية")

--- a/scripts/make_boundaries.py
+++ b/scripts/make_boundaries.py
@@ -165,6 +165,7 @@ COUNTRIES = [
     "TV",  # Tuvalu
     "TR",  # Turkey
     "TM",  # Turkmenistan
+    "UA",  # Ukraine
     "UG",  # Uganda
     "GB",  # United Kingdom
     "US",  # United States of America
@@ -187,7 +188,6 @@ COUNTRIES = [
     #"RU",  # Russia
     "RS",  # Serbia
     "TJ",  # Tajikistan
-    #"UA",  # Ukraine
     "KZ",  # Kazakhstan
     "AM",  # Armenia
     "IL",  # Israel

--- a/scripts/make_boundaries.py
+++ b/scripts/make_boundaries.py
@@ -237,7 +237,6 @@ async def get_relation(conn, **tags):
     if not dir.is_dir():
         dir.mkdir(parents=True);
     path = Path('tmp') / 'boundary' / tags.replace('/', '_')
-    print(tags)
     if not path.exists():
         params = {'data': f'[out:json];relation{tags};(._;>;);out body;'}
         resp = requests.get(OVERPASS, params=params)

--- a/scripts/make_boundaries.py
+++ b/scripts/make_boundaries.py
@@ -11,6 +11,7 @@ from postgis.asyncpg import register
 OVERPASS = 'http://overpass-api.de/api/interpreter'
 
 COUNTRIES = [
+    #"DE",  # Germany
     "AD",  # Andorra
     "AO",  # Angola
     "AI",  # Anguilla
@@ -22,6 +23,7 @@ COUNTRIES = [
     "BB",  # Barbados
     "PW",  # Palau
     "BE",  # Belgium
+    "BY",  # Belarus
     "BZ",  # Belize
     "BM",  # Bermuda
     "BO",  # Bolivia
@@ -50,7 +52,6 @@ COUNTRIES = [
     "CU",  # Cuba
     "CI",  # Côte d'Ivoire
     "DK",  # Denmark
-    #"DE",  # Germany
     "DJ",  # Djibouti
     "DM",  # Dominica
     "EC",  # Ecuador
@@ -179,7 +180,6 @@ COUNTRIES = [
     "CZ",  # Czechia
     "GR",  # Greece
     "CY",  # Cyprus
-    #"BY",  # Belarus
     "BG",  # Bulgaria
     "KG",  # Kyrgyzstan
     "MK",  # Macedonia

--- a/scripts/make_boundaries.py
+++ b/scripts/make_boundaries.py
@@ -195,7 +195,7 @@ COUNTRIES = [
     "PS",  # Palestine
     "JO",  # Jordan
     "AE",  # United Arab Emirates
-    "EH",  # Western Sahara
+    "الجمهورية العربية الصحراوية الديمقراطية‎‎",  # Western Sahara
     "SA",  # Saudi Arabia
     "SD",  # Sudan
     "IQ",  # Iraq
@@ -344,7 +344,7 @@ async def process(itl_path: Path=Path('data/boundary.json'),
     add_disputed(halaib_triangle, props)
     for idx, name in enumerate(COUNTRIES):
         polygon, properties = await load_country(conn, name)
-        if 'ISO3166-1:alpha2' in properties and properties['ISO3166-1:alpha2'] == 'EH':
+        if properties['name:en'] == 'Sahrawi Arab Democratic Republic':
             continue
         print(f'''"{properties['name']}",  # {properties['name:en']}''')
         if  'ISO3166-1:alpha2' in properties and properties['ISO3166-1:alpha2'] == 'IL':

--- a/scripts/make_boundaries.py
+++ b/scripts/make_boundaries.py
@@ -11,227 +11,225 @@ from postgis.asyncpg import register
 OVERPASS = 'http://overpass-api.de/api/interpreter'
 
 COUNTRIES = [
-    #"DE",  # Germany
     "AD",  # Andorra
+    "AE",  # United Arab Emirates
+    "AF",  # Afghanistan
     "AO",  # Angola
-    "AI",  # Anguilla
     "AG",  # Antigua and Barbuda
+    "AI",  # Anguilla
+    "AL",  # Albania
+    "AM",  # Armenia
     "AR",  # Argentina
+    "AT",  # Austria
     "AU",  # Australia
-    "HT",  # Haiti
     "AZ",  # Azerbaijan
-    "BB",  # Barbados
-    "PW",  # Palau
-    "BE",  # Belgium
-    "BY",  # Belarus
-    "BZ",  # Belize
-    "BM",  # Bermuda
-    "BO",  # Bolivia
     "BA",  # Bosnia and Herzegovina
-    "BW",  # Botswana
-    "BR",  # Brazil
-    "IO",  # British Indian Ocean Territory
-    "British Sovereign Base Areas",  # British Sovereign Base Areas
-    "VG",  # British Virgin Islands
-    "BN",  # Brunei
+    "BB",  # Barbados
+    "BD",  # Bangladesh
+    "BE",  # Belgium
     "BF",  # Burkina Faso
+    "BG",  # Bulgaria
+    "BH",  # Bahrain
     "BI",  # Burundi
     "BJ",  # Benin
-    "CV",  # Cape Verde
-    "CM",  # Cameroon
+    "BM",  # Bermuda
+    "BN",  # Brunei
+    "BO",  # Bolivia
+    "BR",  # Brazil
+    "British Sovereign Base Areas",  # British Sovereign Base Areas
+    "BS",  # The Bahamas
+    "BT",  # Bhutan
+    "BW",  # Botswana
+    "BY",  # Belarus
+    "BZ",  # Belize
     "CA",  # Canada
-    "KY",  # Cayman Islands
-    "CL",  # Chile
-    "CA",  # Vatican City
-    "CO",  # Colombia
-    "KM",  # Comoros
+    "CD",  # Democratic Republic of the Congo
+    "CF",  # Central African Republic
     "CG",  # Congo-Brazzaville
-    "CK",  # Cook Islands
-    "CR",  # Costa Rica
-    "ME",  # Montenegro
-    "CU",  # Cuba
+    "CH",  # Switzerland
     "CI",  # Côte d'Ivoire
+    "CK",  # Cook Islands
+    "CL",  # Chile
+    "CM",  # Cameroon
+    "CN",  # CHINA
+    "CO",  # Colombia
+    "CR",  # Costa Rica
+    "CU",  # Cuba
+    "CV",  # Cape Verde
+    "CY",  # Cyprus
+    "CZ",  # Czechia
+    "DE",  # Germany
     "DK",  # Denmark
     "DJ",  # Djibouti
     "DM",  # Dominica
+    "DO",  # Dominican Republic
+    "DZ",  # Algeria
     "EC",  # Ecuador
     "EE",  # Estonia
-    "SV",  # El Salvador
+    "EG",  # Egypt
+    "ER",  # Eritrea
     "ES",  # Spain
-    "SZ",  # Swaziland
+    "ET",  # Ethiopia
+    "FI",  # Finland
+    "FJ",  # Fiji
     "FK",  # Falkland Islands
-    "FR",  # France
+    "FM",  # Federated States of Micronesia
     "FO",  # Faroe Islands
+    "FR",  # France
     "GA",  # Gabon
-    "GM",  # Gambia
+    "GB",  # United Kingdom
+    "GD",  # Grenada
+    "GE",  # Georgia
+    "GG",  # Guernsey
     "GH",  # Ghana
     "GI",  # Gibraltar
-    "GD",  # Grenada
-    "GT",  # Guatemala
-    "GG",  # Guernsey
-    "GQ",  # Equatorial Guinea
-    "GW",  # Guinea-Bissau
+    "GL",  # Greenland
+    "GM",  # Gambia
     "GN",  # Guinea
+    "GQ",  # Equatorial Guinea
+    "GR",  # Greece
+    "GS",  # South Georgia and the South Sandwich Islands
+    "GT",  # Guatemala
+    "GW",  # Guinea-Bissau
     "GY",  # Guyana
     "HN",  # Honduras
     "HR",  # Croatia
-    "IN",  # India
+    "HT",  # Haiti
+    "HU",  # Hungary
     "ID",  # Indonesia
     "IE",  # Ireland
-    "IM",  # Isle of Man
-    "IT",  # Italy
-    "JM",  # Jamaica
-    "JE",  # Jersey
-    "GL",  # Greenland
-    "KE",  # Kenya
-    "KI",  # Kiribati
-    "CF",  # Central African Republic
-    "LV",  # Latvia
-    "LS",  # Lesotho
-    "LR",  # Liberia
-    "LY",  # Liechtenstein
-    "LT",  # Lithuania
-    "LU",  # Luxembourg
-    "MG",  # Madagascar
-    "HU",  # Hungary
-    "MW",  # Malawi
-    "MY",  # Malaysia
-    "ML",  # Mali
-    "MT",  # Malta
-    "MA",  # Morocco
-    "MU",  # Mauritius
-    "FM",  # Federated States of Micronesia
-    "MD",  # Moldova
-    "MC",  # Monaco
-    "MS",  # Montserrat
-    "MZ",  # Mozambique
-    "MX",  # Mexico
-    "MH",  # Marshall Islands
-    "NA",  # Namibia
-    "NR",  # Nauru
-    "NL",  # The Netherlands
-    "NZ",  # New Zealand
-    "NI",  # Nicaragua
-    "NE",  # Niger
-    "NG",  # Nigeria
-    "NU",  # Niue
-    "NO",  # Norway
-    "UZ",  # Uzbekistan
-    "PA",  # Panama
-    "PG",  # Papua New Guinea
-    "PY",  # Paraguay
-    "PE",  # Peru
-    "PH",  # Philippines
-    "PN",  # Pitcairn Islands
-    "PL",  # Poland
-    "PT",  # Portugal
-    "XK",  # Kosovo
-    "DO",  # Dominican Republic
-    "RO",  # Romania
-    "RW",  # Rwanda
-    "CD",  # Democratic Republic of the Congo
-    "SH",  # Saint Helena, Ascension and Tristan da Cunha
-    "KN",  # Saint Kitts and Nevis
-    "LC",  # Saint Lucia
-    "VC",  # Saint Vincent and the Grenadines
-    "SM",  # San Marino
-    "CH",  # Switzerland
-    "SC",  # Seychelles
-    "AL",  # Albania
-    "SL",  # Sierra Leone
-    "SG",  # Singapore
-    "SI",  # Slovenia
-    "SK",  # Slovakia
-    "SB",  # Solomon Islands
-    "SO",  # Somalia
-    "ZA",  # South Africa
-    "GS",  # South Georgia and the South Sandwich Islands
-    "SS",  # South Sudan
-    "FI",  # Finland
-    "SR",  # Suriname
-    "SE",  # Sweden
-    "ST",  # São Tomé and Príncipe
-    "SN",  # Senegal
-    "WS",  # Samoa
-    "TZ",  # Tanzania
-    "TD",  # Chad
-    "BS",  # The Bahamas
-    "TL",  # East Timor
-    "TG",  # Togo
-    "TK",  # Tokelau
-    "TO",  # Tonga
-    "TT",  # Trinidad and Tobago
-    "TC",  # Turks and Caicos Islands
-    "TV",  # Tuvalu
-    "TR",  # Turkey
-    "TM",  # Turkmenistan
-    "UA",  # Ukraine
-    "UG",  # Uganda
-    "GB",  # United Kingdom
-    "US",  # United States of America
-    "UY",  # Uruguay
-    "VU",  # Vanuatu
-    "VE",  # Venezuela
-    "FJ",  # Fiji
-    "VN",  # Vietnam
-    "ZM",  # Zambia
-    "ZW",  # Zimbabwe
-    "IS",  # Iceland
-    "AT",  # Austria
-    "CZ",  # Czechia
-    "GR",  # Greece
-    "CY",  # Cyprus
-    "BG",  # Bulgaria
-    "KG",  # Kyrgyzstan
-    "MK",  # Macedonia
-    "MN",  # Mongolia
-    #"RU",  # Russia
-    "RS",  # Serbia
-    "TJ",  # Tajikistan
-    "KZ",  # Kazakhstan
-    "AM",  # Armenia
     "IL",  # Israel
-    "AF",  # Afghanistan
-    "PS",  # Palestine
-    "JO",  # Jordan
-    "AE",  # United Arab Emirates
-    "الجمهورية العربية الصحراوية الديمقراطية‎‎",  # Western Sahara
-    "SA",  # Saudi Arabia
-    "SD",  # Sudan
+    "IM",  # Isle of Man
+    "IN",  # India
+    "IO",  # British Indian Ocean Territory
     "IQ",  # Iraq
-    "YE",  # Yemen
-    "TN",  # Tunisia
-    "SY",  # Syria
-    "OM",  # Oman
-    "LB",  # Lebanon
-    "EG",  # Egypt
-    "MR",  # Mauritania
-    "MV",  # Maldives
-    "NP",  # Nepal
-    "BD",  # Bangladesh
-    "LK",  # Sri Lanka
-    "TH",  # Thailand
-    "LA",  # Laos
-    "BT",  # Bhutan
-    "MM",  # Myanmar
-    "GE",  # Georgia
-    "ET",  # Ethiopia
-    "ER",  # Eritrea
-    "KH",  # Cambodia
-    "BH",  # Bahrain
-    "KW",  # Kuwait
     "IR",  # Iran
-    "QA",  # Qatar
-    "PK",  # Pakistan
-    "LY",  # Libya
-    "DZ",  # Algeria
-    "CN",  # China
-    "JP",  # Japan
-    "TW",  # Taiwan
+    "IS",  # Iceland
+    "IT",  # Italy
+    "JE",  # Jersey
+    "JM",  # Jamaica
+    "JO",  # Jordan
+    "KE",  # Kenya
+    "KG",  # Kyrgyzstan
+    "KH",  # Cambodia
+    "KI",  # Kiribati
+    "KM",  # Comoros
+    "KN",  # Saint Kitts and Nevis
     "KR",  # South Korea
     "KP",  # North Korea
+    "KW",  # Kuwait
+    "KY",  # Cayman Islands
+    "KZ",  # Kazakhstan
+    "LA",  # Laos
+    "LB",  # Lebanon
+    "LC",  # Saint Lucia
+    "LI",  # Liechtenstein
+    "LK",  # Sri Lanka
+    "LS",  # Lesotho
+    "LR",  # Liberia
+    "LT",  # Lithuania
+    "LU",  # Luxembourg
+    "LV",  # Latvia
+    "LY",  # Libya
+    "MA",  # Morocco
+    "MC",  # Monacos
+    "MD",  # Moldova
+    "ME",  # Montenegro
+    "MG",  # Madagascar
+    "MH",  # Marshall Islands
+    "MK",  # Macedonia
+    "ML",  # Mali
+    "MM",  # Myanmar
+    "MN",  # Mongolia
+    "MR",  # Mauritania
+    "MS",  # Montserrat
+    "MT",  # Malta
+    "MU",  # Mauritius
+    "MV",  # Maldives
+    "MW",  # Malawi
+    "MX",  # Mexico
+    "MY",  # Malaysia
+    "MZ",  # Mozambique
+    "NA",  # Namibia
+    "NE",  # Niger
+    "NG",  # Nigeria
+    "NI",  # Nicaragua
+    "NL",  # The Netherlands
+    "NO",  # Norway
+    "NP",  # Nepal
+    "NR",  # Nauru
+    "NU",  # Niue
+    "NZ",  # New Zealand
+    "OM",  # Oman
+    "PA",  # Panama
+    "PE",  # Peru
+    "PG",  # Papua New Guinea
+    "PH",  # Philippines
+    "PK",  # Pakistan
+    "PL",  # Poland
+    "PN",  # Pitcairn Islands
+    "PS",  # Palestine
+    "PT",  # Portugal
+    "PW",  # Palau
+    "PY",  # Paraguay
+    "QA",  # Qatar
+    "RO",  # Romania
+    "RS",  # Serbia
+    "RU",  # Russia
+    "RW",  # Rwanda
+    "SA",  # Saudi Arabia
+    "SB",  # Solomon Islands
+    "SC",  # Seychelles
+    "SD",  # Sudan
+    "SE",  # Sweden
+    "SG",  # Singapore
+    "SH",  # Saint Helena, Ascension and Tristan da Cunha
+    "SI",  # Slovenia
+    "SK",  # Slovakia
+    "SL",  # Sierra Leone
+    "SM",  # San Marino
+    "SN",  # Senegal
+    "SO",  # Somalia
+    "SR",  # Suriname
+    "SS",  # South Sudan
+    "ST",  # São Tomé and Príncipe
+    "SV",  # El Salvador
+    "SY",  # Syria
+    "SZ",  # Swaziland
+    "TC",  # Turks and Caicos Islands
+    "TD",  # Chad
+    "TG",  # Togo
+    "TH",  # Thailand
+    "TJ",  # Tajikistan
+    "TK",  # Tokelau
+    "TL",  # East Timor
+    "TM",  # Turkmenistan
+    "TN",  # Tunisia
+    "TO",  # Tonga
+    "TR",  # Turkey
+    "TT",  # Trinidad and Tobago
+    "TV",  # Tuvalu
+    "TW",  # Taiwan
+    "TZ",  # Tanzania
+    "UA",  # Ukraine
+    "UG",  # Uganda
+    "US",  # United States of America
+    "UY",  # Uruguay
+    "UZ",  # Uzbekistan
+    "VA",  # Vatican City
+    "VC",  # Saint Vincent and the Grenadines
+    "VE",  # Venezuela
+    "VG",  # British Virgin Islands
+    "VN",  # Vietnam
+    "VU",  # Vanuatu
+    "WS",  # Samoa
+    "XK",  # Kosovo
+    "YE",  # Yemen
+    "ZA",  # South Africa
+    "ZM",  # Zambia
+    "ZW",  # Zimbabwe
+    "الجمهورية العربية الصحراوية الديمقراطية‎‎",  # Western Sahara
 ]
-
 
 async def get_relation(conn, **tags):
     tags = "".join(f'["{k.replace("iso","ISO3166-1:alpha2") if (k == "iso" and len(v) == 2) else k.replace("iso","name")}"="{v}"]' for k, v in tags.items())


### PR DESCRIPTION
The `make boundary` is now fully working on OSX, partially fix #13 (for `sed --in-place`)

Fix #12, if there is no `tmp/boundary/` folder available, we create it.

Fix #15, relying on ISO country code better than name to use the overpass API, this shouldn't change.

