### PR TITLE
Better management of visual icons for cities and text size of cities

### DIFF
--- a/icon/place/capital.svg
+++ b/icon/place/capital.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 6 6"><path fill="#525252" stroke="#525252" stroke-miterlimit="10" d="M.5.5h5v5h-5z"/></svg>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 7.9 7.6"><path class="st1" fill="#fff" stroke="#525252" d="M6.4 7.5L4 6.3 1.6 7.6l.5-2.7-2.1-2 2.7-.5L3.9 0l1.3 2.5 2.7.5L6 4.9l.4 2.6z"/></svg>

--- a/icon/place/capital.svg
+++ b/icon/place/capital.svg
@@ -1,1 +1,3 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 7.9 7.6"><path class="st1" fill="#fff" stroke="#525252" d="M6.4 7.5L4 6.3 1.6 7.6l.5-2.7-2.1-2 2.7-.5L3.9 0l1.3 2.5 2.7.5L6 4.9l.4 2.6z"/></svg>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 7.9 7.6">
+<path fill="#fff" stroke="#525252" d="M6.4 7.5L4 6.3 1.6 7.6l.5-2.7-2.1-2 2.7-.5L3.9 0l1.3 2.5 2.7.5L6 4.9l.4 2.6z"/>
+</svg>

--- a/icon/place/city.svg
+++ b/icon/place/city.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 6 6"><path fill="none" stroke="#525252" stroke-miterlimit="10" d="M.5.5h5v5h-5z"/></svg>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 6 6"><path class="st0" fill="#FFF" stroke="#525252" d="M.5.5h5v5h-5v-5z"/></svg>

--- a/icon/place/city.svg
+++ b/icon/place/city.svg
@@ -1,3 +1,3 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 6 6">	
-<path class="st0" fill="#FFF" stroke="#525252" d="M.5.5h5v5h-5v-5z"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 6 6">
+<path fill="#fff" stroke="#525252" d="M1.2,0.5h4.3v4.3H1.2V0.5z"/>
 </svg>

--- a/icon/place/city.svg
+++ b/icon/place/city.svg
@@ -1,1 +1,3 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 6 6"><path class="st0" fill="#FFF" stroke="#525252" d="M.5.5h5v5h-5v-5z"/></svg>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 6 6">	
+<path class="st0" fill="#FFF" stroke="#525252" d="M.5.5h5v5h-5v-5z"/>
+</svg>

--- a/icon/place/embassy.svg
+++ b/icon/place/embassy.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 7.9 7.6"><path d="M6.1 7L4 5.9 1.9 7.1l.4-2.4L.5 3l2.4-.4 1-2.2L5 2.6l2.4.4-1.7 1.7.4 2.3z" opacity=".3" fill="none" stroke="#fff" stroke-linejoin="round"/><path d="M6.1 7L4 5.9 1.9 7.1l.4-2.4L.5 3l2.4-.4 1-2.2L5 2.6l2.4.4-1.7 1.7.4 2.3z" fill="#525252" stroke="#525252" stroke-miterlimit="10"/></svg>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 7.9 7.6"><path class="st1" fill="#525252" stroke="#999" d="M6.4 7.5L4 6.3 1.6 7.6l.5-2.7-2.1-2 2.7-.5L3.9 0l1.3 2.5 2.7.5L6 4.9l.4 2.6z"/></svg>

--- a/icon/place/embassy.svg
+++ b/icon/place/embassy.svg
@@ -1,1 +1,3 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 7.9 7.6"><path class="st1" fill="#525252" stroke="#999" d="M6.4 7.5L4 6.3 1.6 7.6l.5-2.7-2.1-2 2.7-.5L3.9 0l1.3 2.5 2.7.5L6 4.9l.4 2.6z"/></svg>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 7.9 7.6">
+<path fill="#525252" stroke="#525252" d="M6.4,7.5L4,6.3L1.6,7.6l0.5-2.7L0,2.9l2.7-0.5L3.9,0l1.3,2.5L7.9,3L6,4.9L6.4,7.5z"/>
+</svg>

--- a/icon/place/intermediate.svg
+++ b/icon/place/intermediate.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 7.9 7.6"><path d="M6.1 7L4 5.9 1.9 7.1l.4-2.4L.5 3l2.4-.4 1-2.2L5 2.6l2.4.4-1.7 1.7.4 2.3z" opacity=".3" fill="none" stroke="#fff" stroke-linejoin="round"/><path d="M6.1 7L4 5.9 1.9 7.1l.4-2.4L.5 3l2.4-.4 1-2.2L5 2.6l2.4.4-1.7 1.7.4 2.3z" fill="none" stroke="#525252" stroke-miterlimit="10"/></svg>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 6 6"><path class="st0" fill="#525252" stroke="#525252" d="M.5.5h5v5h-5v-5z"/></svg>

--- a/icon/place/intermediate.svg
+++ b/icon/place/intermediate.svg
@@ -1,3 +1,3 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 6 6">
-<path fill="#525252" stroke="#525252" d="M.5.5h5v5h-5v-5z"/>
+<path fill="#525252" stroke="#525252" d="M1.2,0.5h4.3v4.3H1.2V0.5z"/>
 </svg>

--- a/icon/place/intermediate.svg
+++ b/icon/place/intermediate.svg
@@ -1,1 +1,3 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 6 6"><path class="st0" fill="#525252" stroke="#525252" d="M.5.5h5v5h-5v-5z"/></svg>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 6 6">
+<path fill="#525252" stroke="#525252" d="M.5.5h5v5h-5v-5z"/>
+</svg>

--- a/icon/place/town.svg
+++ b/icon/place/town.svg
@@ -1,1 +1,3 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 6 6"><circle class="st0" cx="3" fill="none" stroke="#525252" cy="3" r="2.5"/></svg>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 6 6">
+<circle cx="2.5" cy="2.5" r="3" fill="#fff" stroke="#525252"/>
+</svg>

--- a/icon/place/town.svg
+++ b/icon/place/town.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="6" height="6"><g transform="matrix(.8 0 0 .8 -4.224 5.402)"><circle cx="9" cy="-3" r="2" opacity=".3" fill="none" stroke="#fff" stroke-width="1.25"/><circle cx="9" cy="-3" r="2" fill="#525252"/></g></svg>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 6 6"><circle class="st0" cx="3" fill="none" stroke="#525252" cy="3" r="2.5"/></svg>

--- a/icon/place/town.svg
+++ b/icon/place/town.svg
@@ -1,3 +1,3 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 6 6">
-<circle cx="2.5" cy="2.5" r="3" fill="#fff" stroke="#525252"/>
+<circle cx="3" fill="#fff" stroke="#525252" cy="3" r="2.5"/>
 </svg>

--- a/labels.mss
+++ b/labels.mss
@@ -61,7 +61,7 @@
 #place_low[type='city'][zoom>=7][zoom<=10],
 #place_low[type='town'][zoom>=9][zoom<=10] {
   shield-file: url('icon/place/[type].svg');
-  shield-name:'[name]';
+  shield-name:[name];
   shield-size: 11;
   shield-face-name: @regular;
   shield-halo-radius: 1;
@@ -69,13 +69,14 @@
   shield-fill: @town_text;
   shield-halo-fill: @halo;
   shield-placement-type: simple;
-  shield-placements: 'NE,SW,NW,SE,E,W';
+  shield-placements: 'NE,SW,NW,SE,E,W,N,S';
   shield-text-dy: 2;
   shield-text-dx: 6;
   shield-unlock-image: true;
   shield-min-distance: 10;
   [type='town'] {
-    shield-text-dx: 2;
+    shield-text-dx: 4;
+    shield-text-dy: 4;
   }
   [type='city'] {
     shield-line-spacing: -2;
@@ -86,15 +87,13 @@
   [type='embassy'], [type='capital'] {
     shield-fill: @city_text;
     shield-face-name: @bold;
-    shield-size: 13;
-    [type='embassy'] {
-      shield-allow-overlap: true;
-    }
+    shield-size: 12;
+    shield-allow-overlap: true;
   }
   [type='intermediate'] {
     shield-face-name: @medium;
     shield-fill: @city_text;
-    shield-size: 12;
+    shield-size: 11;
   }
   [ldir!=null] {
     shield-placements: '[ldir]';
@@ -105,13 +104,19 @@
   [zoom>=9] {
     shield-size: 12;
     [type='embassy'], [type='capital'], [type='intermediate'] {
-      shield-size: 15;
+      shield-size: 17;
+      shield-placements: 'N';
+      shield-text-dy: 8;
+    }
+    [type='city'] {
+      shield-size: 14;
     }
   }
 }
-#place[type='city'][zoom>=10],
-#place[type='town'][zoom>=10],
-#place[type='village'][zoom>=9],
+#city[zoom>10],
+#place[type='city'][zoom>10],
+#place[type='town'][zoom>10],
+#place[type='village'][zoom>=11],
 #place[type='minor'][zoom>=14] {
   text-name: '[name]';
   [lang='fr'] {
@@ -120,10 +125,10 @@
   text-face-name: @light;
   text-placement: point;
   text-fill: @village_text;
-  text-size: 12;
+  text-size: 11;
   text-halo-fill: @halo;
   text-halo-radius: 2;
-  text-wrap-width: 40;
+  text-wrap-width: 45;
   text-label-position-tolerance: 20;
   text-character-spacing: 0.1;
   text-line-spacing: -2;
@@ -132,10 +137,16 @@
   [type='town'] {
     text-fill: @town_text;
     text-face-name: @regular;
+    text-size: 13;
   }
   [type='city'] {
     text-fill: @city_text;
     text-face-name: @medium;
+    text-size: 14;
+  }
+  [type='intermediate'], [type='embassy'], [type='capital'] {
+    text-face-name: @bold;
+  	text-size:16;
   }
   [type='minor'] {
     text-margin: 50;
@@ -143,21 +154,30 @@
   [zoom>=12] {
     text-margin: 10;
     text-min-padding: 1;
-    text-size: 13;
-    [type='city'] {
+    text-size: 12;
+    [type='town'] {
       text-size: 14;
+    }
+    [type='city'] {
+      text-size: 16;
+    }
+    [type='intermediate'], [type='embassy'], [type='capital'] {
+      text-size: 18;
     }
   }
   [zoom>=13] {
-    text-size: 14;
-    [type='city'] {
-      text-size: 15;
-    }
-  }
-  [zoom>=14] {
-    text-size: 15;
+    text-size: 13;
     [type='minor'] {
       text-size: 10;
+    }
+    [type='town'] {
+      text-size: 15;
+    }
+    [type='city'] {
+      text-size: 17;
+    }
+    [type='intermediate'], [type='embassy'], [type='capital'] {
+      text-size: 19;
     }
   }
 }


### PR DESCRIPTION
Cities with french embassy = black stars, Capital city without french embassy = white stars:

<img width="1381" alt="embassies_capitales_stars" src="https://user-images.githubusercontent.com/178744/42227219-496491e4-7ee1-11e8-85fe-b5313cd4750c.png">

Cities with french presence = black square, Cities in general = white square:

<img width="1380" alt="cities_with_without_french_presence" src="https://user-images.githubusercontent.com/178744/42227309-8391b914-7ee1-11e8-91c1-96ad049d3062.png">

Mix of cities and towns at zoom 9:

<img width="1379" alt="mix_cities_and_towns_zoom_9" src="https://user-images.githubusercontent.com/178744/42227392-b30557b4-7ee1-11e8-9521-f38ab36ce455.png">

Mix of cities and towns at zoom 11:

<img width="1380" alt="mix_cities_and_towns_zoom_11" src="https://user-images.githubusercontent.com/178744/42227421-c5af73e0-7ee1-11e8-96e0-77cab0fb37fa.png">
