### PR TITLE
Cities order

### DIFF
--- a/forte.yml
+++ b/forte.yml
@@ -302,7 +302,7 @@ Layer:
     table: |-
         ( SELECT
             geometry, '{lang}' as lang, type, NULL as ldir,
-            CASE WHEN type='city' THEN 1 WHEN type='state' THEN 2 ELSE 100 END AS prio,
+            CASE WHEN capital='yes' THEN 1 WHEN capital IN ('2','3','4') THEN 2 WHEN type='state' THEN 3 ELSE 100 END AS prio,
             CASE WHEN capital='yes' THEN 1 WHEN capital IN ('2','3','4','5','6','7','8','9','10') THEN capital::INT ELSE 100 END AS capital,
             COALESCE(NULLIF(name{lang}, ''), NULLIF(int_name, ''), name) as name
           FROM
@@ -312,7 +312,7 @@ Layer:
             AND type IN ('state', 'city', 'town')
             AND geometry && !bbox!
           ORDER BY
-            capital ASC, prio, population DESC NULLS LAST
+            prio, capital ASC, population DESC NULLS LAST
         ) AS data
 
 - id: place

--- a/forte.yml
+++ b/forte.yml
@@ -312,7 +312,7 @@ Layer:
             AND type IN ('state', 'city', 'town')
             AND geometry && !bbox!
           ORDER BY
-            prio, capital ASC, population DESC NULLS LAST
+            prio ASC, capital ASC, population DESC NULLS LAST
         ) AS data
 
 - id: place

--- a/forte.yml
+++ b/forte.yml
@@ -303,7 +303,7 @@ Layer:
         ( SELECT
             geometry, '{lang}' as lang, type, NULL as ldir,
             CASE WHEN type='city' THEN 1 WHEN type='state' THEN 2 ELSE 100 END AS prio,
-            CASE WHEN capital='yes' THEN 1 WHEN capital IN ('4','5','6','7','8','9','10') THEN capital::INT ELSE 100 END AS capital,
+            CASE WHEN capital='yes' THEN 1 WHEN capital IN ('2','3','4','5','6','7','8','9','10') THEN capital::INT ELSE 100 END AS capital,
             COALESCE(NULLIF(name{lang}, ''), NULLIF(int_name, ''), name) as name
           FROM
             osm_places
@@ -326,7 +326,7 @@ Layer:
             geometry, '{lang}' as lang,
             CASE WHEN type='city' THEN 1 WHEN type='town' THEN 2 ELSE 100 END AS prio,
             CASE WHEN type IN ('hamlet', 'suburb', 'isolated_dwelling', 'neighbourhood', 'allotments', 'city_block') THEN 'minor' ELSE type END AS type,
-            CASE WHEN capital='yes' THEN 1 WHEN capital IN ('4','5','6','7','8','9','10') THEN capital::INT ELSE 100 END AS capital,
+            CASE WHEN capital='yes' THEN 1 WHEN capital IN ('2','3','4','5','6','7','8','9','10') THEN capital::INT ELSE 100 END AS capital,
             population, 
             COALESCE(NULLIF(name{lang}, ''), NULLIF(int_name, ''), name) as name
           FROM

--- a/forte.yml
+++ b/forte.yml
@@ -301,8 +301,9 @@ Layer:
     <<: *db
     table: |-
         ( SELECT
-            geometry, '{lang}' as lang, type, capital, NULL as ldir,
+            geometry, '{lang}' as lang, type, NULL as ldir,
             CASE WHEN type='city' THEN 1 WHEN type='state' THEN 2 ELSE 100 END AS prio,
+            CASE WHEN capital='yes' THEN 1 WHEN capital IN ('4','5','6','7','8','9','10') THEN capital::INT ELSE 100 END AS capital,
             COALESCE(NULLIF(name{lang}, ''), NULLIF(int_name, ''), name) as name
           FROM
             osm_places
@@ -311,7 +312,7 @@ Layer:
             AND type IN ('state', 'city', 'town')
             AND geometry && !bbox!
           ORDER BY
-            prio, capital ASC, population DESC
+            capital ASC, prio, population DESC NULLS LAST
         ) AS data
 
 - id: place
@@ -322,14 +323,16 @@ Layer:
     <<: *db
     table: |-
         ( SELECT
-            geometry, '{lang}' as lang, capital,
+            geometry, '{lang}' as lang,
             CASE WHEN type='city' THEN 1 WHEN type='town' THEN 2 ELSE 100 END AS prio,
             CASE WHEN type IN ('hamlet', 'suburb', 'isolated_dwelling', 'neighbourhood', 'allotments', 'city_block') THEN 'minor' ELSE type END AS type,
-            population, COALESCE(NULLIF(name{lang}, ''), name) as name
+            CASE WHEN capital='yes' THEN 1 WHEN capital IN ('4','5','6','7','8','9','10') THEN capital::INT ELSE 100 END AS capital,
+            population, 
+            COALESCE(NULLIF(name{lang}, ''), NULLIF(int_name, ''), name) as name
           FROM
             osm_places
           ORDER BY
-            prio, population DESC NULLS LAST
+            capital ASC, prio, population DESC NULLS LAST
         ) AS data
 
 - id: station

--- a/labels.mss
+++ b/labels.mss
@@ -70,6 +70,7 @@
   shield-halo-fill: @halo;
   shield-placement-type: simple;
   shield-placements: 'NE,SW,NW,SE,E,W,N,S';
+  shield-min-padding:1;
   shield-text-dy: 2;
   shield-text-dx: 6;
   shield-unlock-image: true;
@@ -129,10 +130,10 @@
   text-halo-fill: @halo;
   text-halo-radius: 2;
   text-wrap-width: 45;
-  text-label-position-tolerance: 20;
+  text-label-position-tolerance: 10;
   text-character-spacing: 0.1;
   text-line-spacing: -2;
-  text-margin: 30;
+  text-margin: 15;
   text-min-padding: 1;
   [type='town'] {
     text-fill: @town_text;

--- a/piano.yml
+++ b/piano.yml
@@ -294,8 +294,9 @@ Layer:
     <<: *db
     table: |-
         ( SELECT
-            geometry, '{lang}' as lang, type, capital, NULL as ldir,
+            geometry, '{lang}' as lang, type, NULL as ldir,
             CASE WHEN type='city' THEN 1 WHEN type='state' THEN 2 ELSE 100 END AS prio,
+            CASE WHEN capital='yes' THEN 1 WHEN capital IN ('4','5','6','7','8','9','10') THEN capital::INT ELSE 100 END AS capital,
             COALESCE(NULLIF(name{lang}, ''), NULLIF(int_name, ''), name) as name
           FROM
             osm_places
@@ -304,7 +305,7 @@ Layer:
             AND type IN ('state', 'city', 'town')
             AND geometry && !bbox!
           ORDER BY
-            prio, capital ASC, population DESC
+            capital ASC, prio ASC, population DESC NULLS LAST
         ) AS data
 
 - id: place
@@ -315,15 +316,16 @@ Layer:
     <<: *db
     table: |-
         ( SELECT
-            geometry, '{lang}' as lang, capital,
+            geometry, '{lang}' as lang,
             CASE WHEN type='city' THEN 1 WHEN type='town' THEN 2 ELSE 100 END AS prio,
             CASE WHEN type IN ('hamlet', 'suburb', 'isolated_dwelling', 'neighbourhood', 'allotments', 'city_block') THEN 'minor' ELSE type END AS type,
+            CASE WHEN capital='yes' THEN 1 WHEN capital IN ('4','5','6','7','8','9','10') THEN capital::INT ELSE 100 END AS capital,
             population,
-            COALESCE(NULLIF(name{lang}, ''), name) as name
+            COALESCE(NULLIF(name{lang}, ''), NULLIF(int_name, ''), name) as name
           FROM
             osm_places
           ORDER BY
-            prio, population DESC NULLS LAST
+            capital ASC, prio, population DESC NULLS LAST
         ) AS data
 
 - id: boundary_label_low

--- a/piano.yml
+++ b/piano.yml
@@ -295,7 +295,7 @@ Layer:
     table: |-
         ( SELECT
             geometry, '{lang}' as lang, type, NULL as ldir,
-            CASE WHEN type='city' THEN 1 WHEN type='state' THEN 2 ELSE 100 END AS prio,
+            CASE WHEN capital='yes' THEN 1 WHEN capital IN ('2','3','4') THEN 2 WHEN type='state' THEN 3 ELSE 100 END AS prio,
             CASE WHEN capital='yes' THEN 1 WHEN capital IN ('2','3','4','5','6','7','8','9','10') THEN capital::INT ELSE 100 END AS capital,
             COALESCE(NULLIF(name{lang}, ''), NULLIF(int_name, ''), name) as name
           FROM
@@ -305,7 +305,7 @@ Layer:
             AND type IN ('state', 'city', 'town')
             AND geometry && !bbox!
           ORDER BY
-            capital ASC, prio ASC, population DESC NULLS LAST
+            prio ASC, capital ASC, population DESC NULLS LAST
         ) AS data
 
 - id: place

--- a/piano.yml
+++ b/piano.yml
@@ -296,7 +296,7 @@ Layer:
         ( SELECT
             geometry, '{lang}' as lang, type, NULL as ldir,
             CASE WHEN type='city' THEN 1 WHEN type='state' THEN 2 ELSE 100 END AS prio,
-            CASE WHEN capital='yes' THEN 1 WHEN capital IN ('4','5','6','7','8','9','10') THEN capital::INT ELSE 100 END AS capital,
+            CASE WHEN capital='yes' THEN 1 WHEN capital IN ('2','3','4','5','6','7','8','9','10') THEN capital::INT ELSE 100 END AS capital,
             COALESCE(NULLIF(name{lang}, ''), NULLIF(int_name, ''), name) as name
           FROM
             osm_places
@@ -319,7 +319,7 @@ Layer:
             geometry, '{lang}' as lang,
             CASE WHEN type='city' THEN 1 WHEN type='town' THEN 2 ELSE 100 END AS prio,
             CASE WHEN type IN ('hamlet', 'suburb', 'isolated_dwelling', 'neighbourhood', 'allotments', 'city_block') THEN 'minor' ELSE type END AS type,
-            CASE WHEN capital='yes' THEN 1 WHEN capital IN ('4','5','6','7','8','9','10') THEN capital::INT ELSE 100 END AS capital,
+            CASE WHEN capital='yes' THEN 1 WHEN capital IN ('2','3','4','5','6','7','8','9','10') THEN capital::INT ELSE 100 END AS capital,
             population,
             COALESCE(NULLIF(name{lang}, ''), NULLIF(int_name, ''), name) as name
           FROM


### PR DESCRIPTION
Change strategy to order cities

First, we order them with capital field (an admin_level 4 capital should
be shown before bigger cities)

Then we use city / town tag to order them

Then we use the population tag.

Should FIX #36

Additionally: Use shield-min-padding to avoid cutted letters